### PR TITLE
修复更改昵称以及昵称中有空格时，群@功能失效的问题

### DIFF
--- a/src/handlers/on-message.js
+++ b/src/handlers/on-message.js
@@ -113,7 +113,7 @@ async function dispatchRoomFilterByMsgType(that, room, msg) {
       case that.Message.Type.Text:
         content = msg.text();
         console.log(`群名: ${roomName} 发消息人: ${contactName} 内容: ${content}`);
-        const mentionSelf = content.includes(`@${userSelfName}`);
+        const mentionSelf = await msg.mentionSelf();
 
         content = content.replace(/@[^,，：:\s@]+/g, "").trim();
         // 检测是否需要这条消息

--- a/src/handlers/on-message.js
+++ b/src/handlers/on-message.js
@@ -104,7 +104,7 @@ async function dispatchRoomFilterByMsgType(that, room, msg) {
     const contactName = contact.name();
     const roomName = await room.topic();
     const type = msg.type();
-    const userSelfName = that.currentUser?.name() || that.userSelf()?.name();
+    const receiver = msg.to();
     let content = "";
     let replys = "";
     let contactId = contact.id || "111";
@@ -114,8 +114,9 @@ async function dispatchRoomFilterByMsgType(that, room, msg) {
         content = msg.text();
         console.log(`群名: ${roomName} 发消息人: ${contactName} 内容: ${content}`);
         const mentionSelf = await msg.mentionSelf();
+        const receiverName = receiver?.name();
 
-        content = content.replace(/@[^,，：:\s@]+/g, "").trim();
+        content = content.replace(receiverName, "").trim();
         // 检测是否需要这条消息
         const isIgnore = checkIgnore(content, aibotConfig.ignoreMessages);
         if (isIgnore) return;

--- a/src/service/room-async-service.js
+++ b/src/service/room-async-service.js
@@ -375,10 +375,8 @@ async function oneToMany(that, config, msg) {
  */
 async function dispatchAsync(that, msg, list) {
   try {
-    const userSelfName = that.currentUser?.name?.()
     const type = msg.type()
-    const content = msg.text()
-    const mentionSelf = content.includes(`@${userSelfName}`)
+    const mentionSelf = await msg.mentionSelf()
     if (7 === type && mentionSelf) {
       // 如果内容中有提及机器人的内容，不进行转发
       return


### PR DESCRIPTION
1. 当机器人名字有空格的时候，消息截取错误

> 比如昵称叫`File Transfer`，`@File Transfer 写一段有雪并且表达遗憾的歌词` 会被截取成 `Transfer 写一段有雪并且表达遗憾的歌词`

2. 修复更改群昵称后，群@功能失效

> [如何获取用户的群昵称 · Issue #103 · wechaty/python-wechaty](https://github.com/wechaty/python-wechaty/issues/103)
没有办法获取群昵称，所以一旦修改群昵称之后，用`userSelfName`判断的方式就不起作用了，不过`wechaty`提供了更好的方法`message.mentionSelf()`
> https://wechaty.js.org/docs/api/message#messagementionself--promise-boolean
